### PR TITLE
Add CI/GHA configuration

### DIFF
--- a/.github/workflows/platformio-ci.yaml
+++ b/.github/workflows/platformio-ci.yaml
@@ -1,0 +1,42 @@
+name: PlatformIO CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v3
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ~/.pio
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install PlatformIO
+        run: |
+          pip install --upgrade --requirement requirements.txt
+
+      - name: Run build
+        run: pio run

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,12 @@ A PlatformIO-compatible build environment for the excellent `BresserWeatherSenso
 Usage
 *****
 
-Baseline::
+Acquire sources::
+
+    git clone https://github.com/daq-tools/bresser-to-mqtt
+    cd bresser-to-mqtt
+
+Build firmware image::
 
     python3 -m venv .venv
     source .venv/bin/activate

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Baseline::
 
     python3 -m venv .venv
     source .venv/bin/activate
-    pip install platformio
+    pip install --upgrade --requirement=requirements.txt
     pio run
 
 More targets::

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,9 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:heltec32v3-esp32s3]
-platform = platformio/espressif32@^6.0.0
+platform = espressif32
+platform_packages =
+    platformio/framework-arduinoespressif32@^3.20006.221224
 board = esp32-s3-devkitc-1
 framework = arduino
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+platformio<7


### PR DESCRIPTION
Let PlatformIO builds run on GitHub Actions, in order to assure that it will not break.